### PR TITLE
prometheus-fastapi-instrumentator 7.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e
 
 build:
-  skip: true # [ py<310 ]
+  skip: true # [py<310]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -20,8 +20,6 @@ requirements:
     - pip
     - python
     - poetry-core >=2.0
-    - toml
-    - fastapi >=0.110.0
   run:
     
     - starlette >=0.30.0,<1.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "prometheus-fastapi-instrumentator" %}
-{% set version = "5.8.1" %}
+{% set version = "7.1.0" %}
 
 
 package:
@@ -7,24 +7,26 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/prometheus-fastapi-instrumentator-{{ version }}.tar.gz
-  sha256: 900e191ecc09a10e928e4d8679b5bf114c47931be9f55f1fbb25baade173e16d
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/prometheus_fastapi_instrumentator-{{ version }}.tar.gz
+  sha256: be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e
 
 build:
+  skip: true # [ py<310 ]
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.6,<4.0
-    - poetry
+    - python
+    - poetry-core >=2.0
     - toml
+    - fastapi >=0.110.0
   run:
-    - fastapi >=0.38.1,<1.0.0
+    
+    - starlette >=0.30.0,<1.0.0
     - prometheus_client >=0.8.0,<1.0.0
-    - python >=3.6,<4.0
+    - python
 
 test:
   imports:
@@ -37,8 +39,11 @@ test:
 about:
   home: https://github.com/trallnag/prometheus-fastapi-instrumentator
   summary: Instrument your FastAPI with Prometheus metrics
-  license: Apache-2.0
+  description: A configurable and modular Prometheus Instrumentator for your FastAPI
+  license: ISC
   license_file: LICENSE
+  dev_url: https://github.com/trallnag/prometheus-fastapi-instrumentator
+  doc_url: https://github.com/trallnag/prometheus-fastapi-instrumentator
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
prometheus-fastapi-instrumentator 7.1.0

**Destination channel:** defaults

Note: Not yet pinned in aggregate

### Links

- Jira ticket: [PKG-11458](https://anaconda.atlassian.net/browse/PKG-11458) 
- upstream repo: https://github.com/trallnag/prometheus-fastapi-instrumentator
- upstream release notes: https://github.com/trallnag/prometheus-fastapi-instrumentator/releases
- conda-forge repo: https://github.com/conda-forge/prometheus-fastapi-instrumentator-feedstock

### Explanation of changes:

- New recipe on the main channel. The whole recipe should be reviewed, though it is slightly based off of the conda-forge recipe.
- Part of vllm dependency chain



[PKG-11458]: https://anaconda.atlassian.net/browse/PKG-11458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ